### PR TITLE
Removed reference to re:Invent and corrected buildspec

### DIFF
--- a/workshop/content/buildpipe/buildspec/_index.en.md
+++ b/workshop/content/buildpipe/buildspec/_index.en.md
@@ -41,7 +41,7 @@ phases:
   post_build:
     commands:
       # Use Post-Build for notifications, git tags, upload artifacts to S3
-      - sam package --template-file template.yaml --s3-bucket $PACKAGE_BUCKET --output-template-file packaged.yaml
+      - sam package --s3-bucket $PACKAGE_BUCKET --output-template-file packaged.yaml
 
 artifacts:
   discard-paths: yes

--- a/workshop/content/canaries/finished/_index.en.md
+++ b/workshop/content/canaries/finished/_index.en.md
@@ -6,16 +6,13 @@ weight = 50
 
 <hr>
 
-#### **Thank you for attending this workshop!**
+#### **Thank you for doing this workshop!**
 #### We hope you learned something. 
-#### Please complete the session survey in the mobile app.
 
 <hr>
 
-#### Stay tuned on this website, we are working on new modules!
-
-#### Coming soon: 
-#### Module 6. Cross-Account Deployments
-#### Module 7. Cross-Region Deployments
+#### Stay tuned on this website as we are working on new modules!
+#### If you have a suggestion or feedback to improve this workshop,
+#### please let us know in our [GitHub repository](https://github.com/aws-samples/aws-serverless-cicd-workshop).
 
 <hr>


### PR DESCRIPTION
*Description of changes:*
- Removed reference to re:Invent session evaluations
- Corrected buildspec.yaml where --template-file was specified in the `sam package` command. Turns out that if you specify this command, SAM ignores the `.aws-build` directory, which causes an issue if your Serverless project uses third-party dependencies as they don't get packaged in the build artifact.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
