### PR TITLE
Adding help message for Cloud9 CDK

### DIFF
--- a/workshop/content/buildpipe/cdkinit/_index.en.md
+++ b/workshop/content/buildpipe/cdkinit/_index.en.md
@@ -12,6 +12,11 @@ npm uninstall -g aws-cdk
 npm install -g aws-cdk
 ```
 
+{{% notice tip %}}
+If the Cloud9 terminal returns an error, use the `--force` flag: `npm install -g aws-cdk --force`
+{{% /notice %}}
+
+
 ### Initialize project
 
 Now, let's create a folder within our _sam-app_ directory where the pipeline code will reside.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a tip to ensure that Cloud9 users are retrieving the latest version of aws-cdk. If a user is on an older version of CDK on Cloud9 (currently 1.38.0 by default), the NPM packages installed will reference a higher package revision that contains a different schema than the core package, causing builds to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
