### PR TITLE
Added Cloud9 EBS resizing script and updated Linuxbrew install URL

### DIFF
--- a/workshop/layouts/partials/menu-footer.html
+++ b/workshop/layouts/partials/menu-footer.html
@@ -4,6 +4,7 @@
         GitHub
     </a>
 </span>
+<br><br>
 <left>
-    <h5 class="copyright">&copy; 2019 Amazon Web Services, Inc. or its Affiliates. All rights reserved.<h5>
+    <a href="https://aws.amazon.com/privacy/?nc1=f_pr">Privacy</a> | <a href="https://aws.amazon.com/terms/?nc1=f_pr">Site Terms</a> | &#169; 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved.
 </left>

--- a/workshop/static/assets/bootstrap.sh
+++ b/workshop/static/assets/bootstrap.sh
@@ -61,7 +61,7 @@ function install_linuxbrew() {
     _logger "[+] Creating touch symlink"
     sudo ln -sf /bin/touch /usr/bin/touch
     _logger "[+] Installing homebrew..."
-    echo | sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+    echo | sh -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
     _logger "[+] Adding homebrew in PATH"
     test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
     test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)

--- a/workshop/static/assets/resize.sh
+++ b/workshop/static/assets/resize.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Specify the desired volume size in GiB as a command-line argument. If not specified, default to 20 GiB.
+SIZE=${1:-20}
+
+# Get the ID of the environment host Amazon EC2 instance.
+INSTANCEID=$(curl http://169.254.169.254/latest/meta-data//instance-id)
+
+# Get the ID of the Amazon EBS volume associated with the instance.
+VOLUMEID=$(aws ec2 describe-instances \
+  --instance-id $INSTANCEID \
+  --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \
+  --output text)
+
+# Resize the EBS volume.
+aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE
+
+# Wait for the resize to finish.
+while [ \
+  "$(aws ec2 describe-volumes-modifications \
+    --volume-id $VOLUMEID \
+    --filters Name=modification-state,Values="optimizing","completed" \
+    --query "length(VolumesModifications)"\
+    --output text)" != "1" ]; do
+sleep 1
+done
+
+if [ $(readlink -f /dev/xvda) = "/dev/xvda" ]
+then
+  # Rewrite the partition table so that the partition takes up all the space that it can.
+  sudo growpart /dev/xvda 1
+ 
+  # Expand the size of the file system.
+  sudo resize2fs /dev/xvda1
+
+else
+  # Rewrite the partition table so that the partition takes up all the space that it can.
+  sudo growpart /dev/nvme0n1 1
+
+  # Expand the size of the file system.
+  sudo resize2fs /dev/nvme0n1p1
+fi


### PR DESCRIPTION
Added resize.sh to assets directory for quick access to EBS volume resizing if needed. Developers reusing the same Cloud9 environment for multiple workshops have encountered ''no space left on device'' errors.

Updated the Linuxbrew install url -- fixed #35 
