### PR TITLE
Update _index.en.md

### DIFF
--- a/workshop/content/java/setup/_index.en.md
+++ b/workshop/content/java/setup/_index.en.md
@@ -18,7 +18,7 @@ ___
 
 [AWS Cloud9](https://aws.amazon.com/cloud9/) is a cloud-based integrated development environment (IDE) that lets you  write, run, and debug code from any machine with just a browser. We recommend using it to run this workshop because it already comes with the necessary set of tools pre-installed, but the workshop is not dependent on it, so you are free to run it from your local computer as well.
 
-If you want to use Cloud9, follow these instructions: [Create a Cloud9 Workspace](/setup/cloud9.html).
+If you want to use Cloud9, follow these instructions: [Create a Cloud9 Workspace](/java/setup/cloud9.html).
 
 ___
 


### PR DESCRIPTION
Update to fix Cloud9 setup link that was broken when the experiment was split for Java/NodeJS

*Issue #, if available:* Broken setup link

*Description of changes:*. Fix setup link to refer to correct link


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
