### PR TITLE
omit SAM installation as current Cloud9 AMIs already contain it

### DIFF
--- a/workshop/static/assets/bootstrap.sh
+++ b/workshop/static/assets/bootstrap.sh
@@ -80,9 +80,10 @@ function install_linuxbrew() {
 
 function main() {
     upgrade_existing_packages
-    install_linuxbrew
+# current Cloud9 AMIs contain a recent SAM version, no install/ upgrade required
+#    install_linuxbrew
     install_utility_tools
-    upgrade_sam_cli
+#    upgrade_sam_cli
 
     echo -e "${RED} [!!!!!!!!!] Open up a new terminal to reflect changes ${NC}"
     _logger "[+] Restarting Shell to reflect changes"


### PR DESCRIPTION
*Issue #, if available:*
#46

*Description of changes:*
omit SAM installation as current Cloud9 AMIs already contain a recent version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
