### PR TITLE
use upgrade instead of install as current Cloud9 AMIs already have SAM CLI installed

### DIFF
--- a/workshop/static/assets/bootstrap.sh
+++ b/workshop/static/assets/bootstrap.sh
@@ -31,7 +31,7 @@ function upgrade_sam_cli() {
     # cfn-lint currently clashing with SAM CLI deps
     ## installing SAM CLI via brew instead
     brew tap aws/tap
-    brew install aws-sam-cli
+    brew upgrade aws-sam-cli
 
     _logger "[+] Updating Cloud9 SAM binary"
     # Allows for local invoke within IDE (except debug run)


### PR DESCRIPTION
*Issue #, if available:* #46

*Description of changes:* use brew upgrade instead of install


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
