### PR TITLE
Fixed code snippets in expand block

### DIFF
--- a/workshop/content/javascript/buildpipe/pipeascode/build/_index.en.md
+++ b/workshop/content/javascript/buildpipe/pipeascode/build/_index.en.md
@@ -46,7 +46,7 @@ pipeline.addStage({
 
 The highlighted code is the new addition: 
 
-{{< highlight js "hl_lines=44-68" >}}
+```js {hl_lines=["44-68"]}
 // lib/pipeline-stack.ts
 
 import * as cdk from '@aws-cdk/core';
@@ -118,7 +118,7 @@ export class PipelineStack extends cdk.Stack {
     
   }
 }
-{{< / highlight >}}
+```
 {{% /expand%}}
 
 ### Deploy the pipeline

--- a/workshop/content/javascript/buildpipe/pipeascode/deploy/_index.en.md
+++ b/workshop/content/javascript/buildpipe/pipeascode/deploy/_index.en.md
@@ -35,7 +35,7 @@ pipeline.addStage({
 
 The highlighted code is the new addition: 
 
-{{< highlight js "hl_lines=70-89" >}}
+```js {hl_lines=["70-89"]}
 // lib/pipeline-stack.ts
 
 import * as cdk from '@aws-cdk/core';
@@ -128,7 +128,7 @@ export class PipelineStack extends cdk.Stack {
     
   }
 }
-{{< / highlight >}}
+```
 {{% /expand%}}
 
 ### Deploy the pipeline

--- a/workshop/content/javascript/buildpipe/pipeascode/source/_index.en.md
+++ b/workshop/content/javascript/buildpipe/pipeascode/source/_index.en.md
@@ -41,7 +41,7 @@ pipeline.addStage({
 
 The highlighted code is the new addition: 
 
-{{< highlight js "hl_lines=16-41" >}}
+```js {hl_lines=["16-41"]}
 // lib/pipeline-stack.ts
 
 import * as cdk from '@aws-cdk/core';
@@ -85,7 +85,7 @@ export class PipelineStack extends cdk.Stack {
     });
   }
 }
-{{< / highlight >}}
+```
 {{% /expand%}}
 
 Since we already have the CodeCommit repository, we don't need to create a new one, we just need to import it using the repository name. 


### PR DESCRIPTION
Issue 64 has been fixed
https://github.com/aws-samples/aws-serverless-cicd-workshop/issues/64

Changed highlight in Shortcode to highlight in Code Fences to make it work with expand functionality.
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
