### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/resources/templates/sam-template-chapter-5.yaml
+++ b/resources/templates/sam-template-chapter-5.yaml
@@ -15,7 +15,7 @@ Resources:
     Properties:
       CodeUri: hello-world/
       Handler: app.lambdaHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       AutoPublishAlias: live
       DeploymentPreference:
         Type: Canary10Percent5Minutes

--- a/workshop/content/javascript/canaries/monitor/_index.en.md
+++ b/workshop/content/javascript/canaries/monitor/_index.en.md
@@ -58,7 +58,7 @@ Resources:
     Properties:
       CodeUri: hello-world/
       Handler: app.lambdaHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       AutoPublishAlias: live
       DeploymentPreference:
         Type: Canary10Percent5Minutes


### PR DESCRIPTION
CloudFormation templates in aws-serverless-cicd-workshop have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.