### PR TITLE
Check if aws-sam-cli is installed before upgrading

### DIFF
--- a/workshop/static/assets/bootstrap.sh
+++ b/workshop/static/assets/bootstrap.sh
@@ -31,7 +31,16 @@ function upgrade_sam_cli() {
     # cfn-lint currently clashing with SAM CLI deps
     ## installing SAM CLI via brew instead
     brew tap aws/tap
-    brew upgrade aws-sam-cli
+
+    # upgrade if aws-sam-cli is installed, install if not
+    set +e
+    brew ls --versions aws-sam-cli
+    if [ $? -eq 0 ]; then
+        brew upgrade aws-sam-cli
+    else
+        brew install aws-sam-cli
+    fi
+    set -e
 
     _logger "[+] Updating Cloud9 SAM binary"
     # Allows for local invoke within IDE (except debug run)


### PR DESCRIPTION
Fixes issue #74

Instead of attempting to upgrade aws-sam-cli, which will throw an error if it's not installed, check if it's installed first.

If it's not installed, install it via brew.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
