### PR TITLE
Fix code formatting for Java PipeAsCode Build step

### DIFF
--- a/workshop/content/java/buildpipe/pipeascode/build/_index.en.md
+++ b/workshop/content/java/buildpipe/pipeascode/build/_index.en.md
@@ -45,7 +45,7 @@ pipeline.addStage(StageOptions.builder()
 
 The highlighted code is the new addition: 
 
-{{< highlight js "hl_lines=45-65" >}}
+```java {hl_lines=["45-65"]}
 // PipelineStack.java
 package com.myorg;
 
@@ -113,7 +113,7 @@ public class PipelineStack extends Stack {
                 .build());
     }
 }
-{{< / highlight >}}
+```
 {{% /expand%}}
 
 ### Deploy the pipeline


### PR DESCRIPTION
Closes: #72 

Fix code formatting for Java code. I've just used the same markdown used by other languages [C#](https://github.com/aws-samples/aws-serverless-cicd-workshop/blob/master/workshop/content/csharp/buildpipe/pipeascode/source/_index.en.md?plain=1#L44) and [Python](https://github.com/aws-samples/aws-serverless-cicd-workshop/blob/master/workshop/content/python/buildpipe/pipeascode/source/_index.en.md?plain=1#L41) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
