### PR TITLE
Updates to CDK install instructions

### DIFF
--- a/workshop/content/javascript/buildpipe/cdkinit/_index.en.md
+++ b/workshop/content/javascript/buildpipe/cdkinit/_index.en.md
@@ -4,17 +4,12 @@ date = 2019-11-01T15:26:09-07:00
 weight = 21
 +++
 
-## Install the latest CDK
+## Install the CDK V1
 
-If you are using Cloud9, the CDK is already pre-installed but it will likely be a few versions old. Run the following commands from the Cloud9 terminal to remove your current version and install the latest one:
+If you are using Cloud9, the CDK is already pre-installed but it will likely be a the CDK V2. Where this workshop was published for AWS CDK V1. Run the following commands from the Cloud9 terminal to remove your current version we will initialize the pipeline with V1 in a bit:
 ```
-npm uninstall -g aws-cdk
-npm install -g aws-cdk
+npm uninstall -g cdk
 ```
-
-{{% notice tip %}}
-If the Cloud9 terminal returns an error, use the `--force` flag: `npm install -g aws-cdk --force`
-{{% /notice %}}
 
 
 ### Initialize project
@@ -29,7 +24,16 @@ cd pipeline
 Initialize a new CDK project within the _pipeline_ folder by running the following command:
 
 ```
-cdk init --language typescript
+npx aws-cdk@1.x init app --language typescript
+```
+
+{{% notice tip %}}
+You will be prompted to install ```aws-cdk@1.x```, go ahead and accept with ```y```.
+{{% /notice %}}
+
+Now add an alias as ```cdk``` for AWS CDK V1:
+```
+alias cdk="npx aws-cdk@1.x"
 ```
 
 Now install the CDK modules that we will be using to build a pipeline: 


### PR DESCRIPTION
*Issue # 86:*
https://github.com/aws-samples/aws-serverless-cicd-workshop/issues/86

The lab code and all the import constructs are for AWS CDK V1, however Cloud9 now comes with CDK V2 and the lab does not work if someone was to copy/paste all the instructions. It requires users to troubleshoot the error.


*Description of changes:*
I've done a small update on the CDK install instructions where it removes the CDK V2 from the default Cloud 9 instance and installs CDK V1 where all the dependencies work perfectly. Also added a CDK alias so no additional workshop instructions needs to be updated. Can not see the Dev branch, so submitting to the master.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
