### PR TITLE
Updates to CDK install instructions

### DIFF
--- a/workshop/content/csharp/buildpipe/cdkinit/_index.en.md
+++ b/workshop/content/csharp/buildpipe/cdkinit/_index.en.md
@@ -4,16 +4,12 @@ date = 2021-08-30T08:30:00-06:00
 weight = 21
 +++
 
-## Install the latest CDK
+## Install the CDK V1
 
-If you are using Cloud9, the CDK is already pre-installed but it will likely be a few versions old. Likewise, the Node.js runtime is outdated.
+If you are using Cloud9, the CDK is already pre-installed but it will likely be a the CDK V2. Where this workshop was published for AWS CDK V1. Run the following commands from the Cloud9 terminal to remove your current version we will initialize the pipeline with V1 in a bit:
 
-Run the following commands from the Cloud9 terminal to update Node.js and and install the latest AWS CDK:
 ```bash
-brew install node@14
-echo 'export PATH="/home/linuxbrew/.linuxbrew/opt/node@14/bin:$PATH"' >> /home/ec2-user/.bash_profile
-. ~/.bash_profile 
-npm install -g aws-cdk
+npm uninstall -g cdk
 ```
 
 ### Initialize project
@@ -28,7 +24,16 @@ cd pipeline
 Initialize a new CDK project within the _pipeline_ folder by running the following command:
 
 ```bash
-cdk init --language csharp
+npx aws-cdk@1.x init app --language csharp
+```
+
+{{% notice tip %}}
+You will be prompted to install ```aws-cdk@1.x```, go ahead and accept with ```y```.
+{{% /notice %}}
+
+Now add an alias as ```cdk``` for AWS CDK V1:
+```bash
+alias cdk="npx aws-cdk@1.x"
 ```
 
 Now install the CDK modules that we will be using to build a pipeline: 

--- a/workshop/content/python/buildpipe/cdkinit/_index.en.md
+++ b/workshop/content/python/buildpipe/cdkinit/_index.en.md
@@ -4,15 +4,12 @@ date = 2021-08-30T08:30:00-06:00
 weight = 21
 +++
 
-## Install the latest CDK
+## Install the CDK V1
 
-If you are using Cloud9, the CDK is already pre-installed but it will likely be a few versions old. Likewise, the Node.js runtime is outdated.
+If you are using Cloud9, the CDK is already pre-installed but it will likely be a the CDK V2. Where this workshop was published for AWS CDK V1. Run the following commands from the Cloud9 terminal to remove your current version we will initialize the pipeline with V1 in a bit:
 
-Run the following commands from the Cloud9 terminal to update Node.js and and install the latest AWS CDK:
 ```bash
-nvm install lts/fermium
-nvm alias default lts/fermium
-npm install -g aws-cdk
+npm uninstall -g cdk
 ```
 
 ### Initialize project
@@ -27,7 +24,16 @@ cd pipeline
 Initialize a new CDK project within the _pipeline_ folder by running the following command:
 
 ```bash
-cdk init --language python
+npx aws-cdk@1.x init app --language python
+```
+
+{{% notice tip %}}
+You will be prompted to install ```aws-cdk@1.x```, go ahead and accept with ```y```.
+{{% /notice %}}
+
+Now add an alias as ```cdk``` for AWS CDK V1:
+```bash
+alias cdk="npx aws-cdk@1.x"
 ```
 
 Now install the CDK modules that we will be using to build a pipeline: 


### PR DESCRIPTION
*Issue #, if available:*
#86 

*Description of changes:*
Similar to JavaScript updates from PR #87 - this fixes Python and C#
* removes the CDK V2 from the default Cloud 9 instance and installs CDK V1 where all the dependencies work perfectly
* added a CDK alias so no additional workshop instructions needs to be updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
