### PR TITLE
Added support for NodeJS 16

### DIFF
--- a/workshop/content/sam/init/_index.en.md
+++ b/workshop/content/sam/init/_index.en.md
@@ -50,18 +50,20 @@ Which runtime would you like to use?
         5 - java11
         6 - java8.al2
         7 - java8
-        8 - nodejs14.x
-        9 - nodejs12.x
-        10 - python3.9
-        11 - python3.8
-        12 - python3.7
-        13 - python3.6
-        14 - ruby2.7
+        8 - nodejs16.x
+        9 - nodejs14.x
+        10 - nodejs12.x
+        11 - python3.9
+        12 - python3.8
+        13 - python3.7
+        14 - python3.6
+        15 - ruby2.7
+        16 - rust (provided.al2)
 ```
 
 {{< tabs >}}
 {{% tab name="Node" %}}
-`nodejs14.x`
+`nodejs16.x`
 {{% /tab %}}
 {{% tab name="python" %}}
 `python3.7`


### PR DESCRIPTION
*Issue #, if available:*

(Add support for nodejs16.x #91)[https://github.com/aws-samples/aws-serverless-cicd-workshop/issues/91]

*Description of changes:*

- Added `nodejs16.x` in the sam cli templates list to reflect most recent version of SAM menu
- Updated recommended version `nodejs14.x` to `nodejs16.x`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
