### PR TITLE
Fix sam_app to sam-app in the Python tab

### DIFF
--- a/workshop/content/local/run/_index.en.md
+++ b/workshop/content/local/run/_index.en.md
@@ -24,7 +24,7 @@ sam local start-api --port 8080
 {{% tab name="python" %}}
 
 ```bash
-cd ~/environment/sam_app
+cd ~/environment/sam-app
 sam local start-api --port 8080
 ```
 


### PR DESCRIPTION
For the change directory command in the first code block on the page.

*Issue #, if available:*
`sam_app` directory does not exist.

*Description of changes:*
Fix directory name to `sam-app`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
