### PR TITLE
Typo in folder name sam-app

### DIFF
--- a/workshop/content/local/run/_index.en.md
+++ b/workshop/content/local/run/_index.en.md
@@ -24,7 +24,7 @@ sam local start-api --port 8080
 {{% tab name="python" %}}
 
 ```bash
-cd ~/environment/sam_app
+cd ~/environment/sam-app
 sam local start-api --port 8080
 ```
 


### PR DESCRIPTION
This should be cd ~/environment/sam-app and not cd ~/environment/sam_app (note: the underscore between sam and app)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
